### PR TITLE
INE Add centralized Claude Code instruction template

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ These documents provide the context and guidelines for code reviews conducted by
 - [Trade-off Policy](docs/agent-context/TRADE_OFF_POLICY.md)
 - [Persistent Review Hierarchy](docs/agent-context/PERSISTENT_REVIEW_HIERARCHY.md)
 - [Output Format](docs/agent-context/OUTPUT_FORMAT.md)
+
+## Agent Configuration
+Templates for AI agent instruction files that are downloaded into each Java repo.
+- [Claude Code Instructions](docs/agent-config/CLAUDE.md) - Template for `.claude/CLAUDE.md` in each repo

--- a/docs/agent-config/CLAUDE.md
+++ b/docs/agent-config/CLAUDE.md
@@ -1,0 +1,32 @@
+# {{SERVICE_NAME}} - Java Team Agent Instructions
+
+> **Scope:** Repo-level extension. Layers on top of the org-wide baseline in the root `CLAUDE.md`.
+> **Owner:** Java Services Team
+
+## Java Team Standards
+
+Read and follow these shared documentation files. They are downloaded from `hp-code-conventions` and kept up to date by the Gradle `downloadAllDocs` task.
+
+- `docs/CODING_STANDARDS.md` - Java coding standards (hexagonal architecture, Kafka patterns, naming conventions, Lombok, constructor injection)
+- `docs/HEXAGONAL_ARCHITECTURE_FOR_JAVA_PROJECTS.md` - Strict layer dependency rules for ports and adapters
+- `docs/ROLE_AND_MINDSET.md` - Pragmatic senior Java developer role and technical focus
+- `docs/FUNDAMENTAL_REFERENCES.md` - Key reference standards and architectural principles
+- `docs/TRADE_OFF_POLICY.md` - Balancing pragmatism with technical excellence
+- `docs/PERSISTENT_REVIEW_HIERARCHY.md` - Prioritized review checklist (reliability > FHIR logic > architecture > aesthetics)
+- `docs/DOCUMENTATION_REVIEW.md` - Documentation review guidelines
+- `docs/OUTPUT_FORMAT.md` - Expected structure for code review outputs
+
+## Service Context
+
+Read `docs/SERVICE_CONTEXT.md` for the service domain model, technical landscape, and architectural details.
+
+## Build Commands
+
+- `./gradlew test` - Run unit tests (also downloads shared docs)
+- `./gradlew itest` - Run integration tests
+- `./gradlew build` - Full build
+- `./gradlew checkstyleMain` - Run checkstyle
+
+## Test Structure
+
+Use `// GIVEN // WHEN // THEN` comment structure in all tests.

--- a/docs/agent-config/CLAUDE.md
+++ b/docs/agent-config/CLAUDE.md
@@ -1,4 +1,4 @@
-# {{SERVICE_NAME}} - Java Team Agent Instructions
+# Java Team Agent Instructions
 
 > **Scope:** Repo-level extension. Layers on top of the org-wide baseline in the root `CLAUDE.md`.
 > **Owner:** Java Services Team

--- a/docs/agent-config/CLAUDE.md
+++ b/docs/agent-config/CLAUDE.md
@@ -20,6 +20,10 @@ Read and follow these shared documentation files. They are downloaded from `hp-c
 
 Read `docs/SERVICE_CONTEXT.md` for the service domain model, technical landscape, and architectural details.
 
+## Before Committing
+
+Always run `./gradlew downloadAllDocs` before your first commit on a branch. If any files in `docs/` or `.claude/` are updated by the task, include those changes in your commit. These are shared team standards that must stay in sync with the latest from `hp-code-conventions`. Failing to include updated docs in a PR causes other developers to silently fall behind on standards.
+
 ## Build Commands
 
 - `./gradlew test` - Run unit tests (also downloads shared docs)


### PR DESCRIPTION
## Summary
- Adds `docs/agent-config/CLAUDE.md` as the shared template for `.claude/CLAUDE.md` in all Java repos
- Centralizes Java team agent instructions so updates propagate automatically via the existing Gradle `downloadAllDocs` task
- Updated README to document the new agent-config directory

## Context
Currently, Claude Code doesn't know about the Java team's coding standards, hexagonal architecture rules, or review hierarchy unless each repo manually creates a `.claude/CLAUDE.md`. This template mirrors what `.github/copilot-instructions.md` does for Copilot — both tools now reference the same underlying docs.

## Consumer Setup
Each Java repo needs to:
1. Add `'agent-config/CLAUDE.md'` to its `docsToDownload` list in `build.gradle`
2. Add special handling to place it at `.claude/CLAUDE.md` instead of `docs/`
3. Extract `docs/SERVICE_CONTEXT.md` from their copilot-instructions.md (section 6)
4. Replace `{{SERVICE_NAME}}` placeholder with the actual service name

task-service will be the first consumer (separate PR).

## Test plan
- [ ] Verify the template renders correctly on GitHub
- [ ] Verify task-service can download and use it (follow-up PR)