### PR TITLE
INE-0001 Add auditVersionPins Gradle task for dependency pin hygiene

### DIFF
--- a/docs/agent-config/CLAUDE.md
+++ b/docs/agent-config/CLAUDE.md
@@ -30,6 +30,13 @@ Always run `./gradlew downloadAllDocs` before your first commit on a branch. If 
 - `./gradlew itest` - Run integration tests
 - `./gradlew build` - Full build
 - `./gradlew checkstyleMain` - Run checkstyle
+- `./gradlew auditVersionPins` - Check if forced dependency pins can be removed by upgrading the Spring Boot BOM
+
+## Dependency Version Pin Hygiene
+
+When working on a ticket that touches `build.gradle` or dependency versions, run `./gradlew auditVersionPins` before committing. If the task reports removable pins, include the BOM upgrade and pin removal in your PR (or create a follow-up ticket if the BOM upgrade is out of scope for the current work).
+
+When adding a new forced version pin (via `resolutionStrategy.eachDependency` or `ext.set`), always include a `because` clause or inline comment with the CVE or GHSA identifier. This allows the audit task to track why the pin exists and when it can be removed.
 
 ## Test Structure
 

--- a/docs/agent-config/CLAUDE.md
+++ b/docs/agent-config/CLAUDE.md
@@ -36,7 +36,7 @@ Always run `./gradlew downloadAllDocs` before your first commit on a branch. If 
 
 The `auditVersionPins` task runs automatically as part of every `./gradlew build` via `check.dependsOn`. It logs a report of forced dependency pins and whether upgrading the Spring Boot BOM or a parent dependency would make them removable. It does not fail the build.
 
-When reviewing a PR or working locally, check the `auditVersionPins` output. If it reports removable pins, create a separate PR that bumps the BOM version and removes the stale pins. Do not bundle the BOM upgrade into the current ticket's PR unless the ticket specifically calls for it.
+When reviewing a PR or working locally, check the `auditVersionPins` output. If it reports removable pins, create a separate PR that bumps the BOM version and removes the stale pins. Do not bundle the BOM upgrade into the current ticket's PR unless the ticket specifically calls for it or the PR author desires and approves it.
 
 When adding a new forced version pin (via `resolutionStrategy.eachDependency` or `ext.set`), always include a `because` clause or inline comment with the CVE or GHSA identifier. This allows the audit task to track why the pin exists and when it can be removed.
 

--- a/docs/agent-config/CLAUDE.md
+++ b/docs/agent-config/CLAUDE.md
@@ -34,7 +34,9 @@ Always run `./gradlew downloadAllDocs` before your first commit on a branch. If 
 
 ## Dependency Version Pin Hygiene
 
-When working on a ticket that touches `build.gradle` or dependency versions, run `./gradlew auditVersionPins` before committing. If the task reports removable pins, include the BOM upgrade and pin removal in your PR (or create a follow-up ticket if the BOM upgrade is out of scope for the current work).
+The `auditVersionPins` task runs automatically as part of every `./gradlew build` via `check.dependsOn`. It logs a report of forced dependency pins and whether upgrading the Spring Boot BOM or a parent dependency would make them removable. It does not fail the build.
+
+When reviewing a PR or working locally, check the `auditVersionPins` output. If it reports removable pins, create a separate PR that bumps the BOM version and removes the stale pins. Do not bundle the BOM upgrade into the current ticket's PR unless the ticket specifically calls for it.
 
 When adding a new forced version pin (via `resolutionStrategy.eachDependency` or `ext.set`), always include a `because` clause or inline comment with the CVE or GHSA identifier. This allows the audit task to track why the pin exists and when it can be removed.
 

--- a/gradle/audit-version-pins.gradle
+++ b/gradle/audit-version-pins.gradle
@@ -3,13 +3,9 @@
  * whether a newer Spring Boot BOM (or other parent BOM) would resolve those deps
  * to the pinned version or higher, making the pin removable.
  *
- * Usage (option A — download via Gradle task, preferred):
- *   Add to downloadAllDocs or a separate downloadGradleScripts task that pulls this file
- *   from hp-code-conventions into gradle/audit-version-pins.gradle, then:
+ * Distributed via the downloadAllDocs pattern — each repo downloads this file into
+ * gradle/audit-version-pins.gradle and applies it locally:
  *     apply from: 'gradle/audit-version-pins.gradle'
- *
- * Usage (option B — apply directly from GitHub):
- *   apply from: 'https://raw.githubusercontent.com/icanbwell/hp-code-conventions/main/gradle/audit-version-pins.gradle'
  *
  * Then run:
  *   ./gradlew auditVersionPins
@@ -20,12 +16,18 @@
  */
 
 import groovy.xml.XmlSlurper
+import java.util.regex.Matcher
 
 tasks.register('auditVersionPins') {
     group = 'verification'
     description = 'Checks if newer BOM versions would resolve forced dependency pins'
 
     doLast {
+        if (gradle.startParameter.offline) {
+            logger.lifecycle("\n⚠ Gradle is in offline mode. Skipping auditVersionPins (requires Maven Central access).")
+            return
+        }
+
         def pins = detectVersionPins(project)
         if (pins.isEmpty()) {
             logger.lifecycle("\n✓ No forced version pins detected in build.gradle.")
@@ -44,7 +46,7 @@ tasks.register('auditVersionPins') {
         }
         logger.lifecycle("\n── Current Spring Boot version: ${currentBootVersion}")
 
-        def newerVersions = fetchNewerSpringBootVersions(currentBootVersion, project)
+        def newerVersions = fetchNewerSpringBootVersions(currentBootVersion)
         if (newerVersions.isEmpty()) {
             logger.lifecycle("  No newer Spring Boot versions found on Maven Central.")
             return
@@ -91,9 +93,6 @@ tasks.register('auditVersionPins') {
 
         def stillPinned = pins.findAll { !removablePins.containsKey(pinKey(it)) }
 
-        // For pins not resolvable via Spring Boot BOM, check if upgrading the direct
-        // parent dependency would transitively include the pinned version.
-        // E.g., upgrading HAPI FHIR might bring in a fixed org.hl7.fhir.core version.
         if (!stillPinned.isEmpty()) {
             def parentUpgrades = checkParentDependencyUpgrades(project, stillPinned)
             if (!parentUpgrades.isEmpty()) {
@@ -135,10 +134,8 @@ tasks.named('check') {
 // ── Pin Detection ──────────────────────────────────────────────────────────────
 
 /**
- * Scans the project's configurations for eachDependency forced versions
- * and ext property overrides that follow Spring Boot's naming convention.
- *
- * Returns a list of maps: [group, name, forcedVersion, reason, type]
+ * Scans build.gradle text for eachDependency forced versions and ext property
+ * overrides that follow Spring Boot's naming convention.
  */
 def detectVersionPins(Project project) {
     def pins = []
@@ -148,12 +145,11 @@ def detectVersionPins(Project project) {
     def lines = buildFile.readLines()
 
     // Pattern 1: resolutionStrategy.eachDependency forced version blocks
-    // Parses the if-block line by line to find group, name, useVersion, because
     String currentGroup = null
     String currentName = null
     boolean inIfBlock = false
 
-    lines.each { line ->
+    lines.eachWithIndex { line, idx ->
         def stripped = line.trim()
 
         def ifMatch = (stripped =~ /if\s*\(\s*details\.requested\.group\s*==\s*['"]([^'"]+)['"]/)
@@ -174,15 +170,11 @@ def detectVersionPins(Project project) {
             def versionMatch = (stripped =~ /details\.useVersion\s+['"]([^'"]+)['"]/)
             if (versionMatch) {
                 def version = versionMatch[0][1]
-                def becauseMatch = null
-                // Look for because on same line or scan ahead
                 def becauseLine = (stripped =~ /details\.because\s+['"]([^'"]+)['"]/)
                 def reason = becauseLine ? becauseLine[0][1] : null
 
                 if (!reason) {
-                    // Check next few lines for the because clause
-                    def lineIdx = lines.indexOf(line)
-                    for (int i = lineIdx + 1; i < Math.min(lineIdx + 3, lines.size()); i++) {
+                    for (int i = idx + 1; i < Math.min(idx + 3, lines.size()); i++) {
                         def nextBecause = (lines[i].trim() =~ /details\.because\s+['"]([^'"]+)['"]/)
                         if (nextBecause) {
                             reason = nextBecause[0][1]
@@ -209,19 +201,16 @@ def detectVersionPins(Project project) {
     }
 
     // Pattern 2: ext.set version overrides that are security pins
-    // Spring Boot's dependency-management plugin uses property names like 'thymeleaf.version'
-    // to override BOM-managed versions. We only flag these as pins if they have a CVE/GHSA
-    // comment, distinguishing security overrides from normal version declarations.
+    // Only flags properties with CVE/GHSA/security comments to distinguish from normal version declarations.
     lines.each { line ->
         def stripped = line.trim()
-        def extMatch = (stripped =~ /set\(\s*['"]([^'"]+)\.version['"]\s*,\s*['"]([^'"]+)['"]\s*\)/)
-        if (extMatch) {
-            def artifactHint = extMatch[0][1]
-            def version = extMatch[0][2]
+        Matcher extMatcher = (stripped =~ /set\(\s*['"]([^'"]+)\.version['"]\s*,\s*['"]([^'"]+)['"]\s*\)/)
+        if (extMatcher.find()) {
+            def artifactHint = extMatcher.group(1)
+            def version = extMatcher.group(2)
             def commentMatch = (stripped =~ /\/\/\s*(.+)$/)
             def comment = commentMatch ? commentMatch[0][1].trim() : null
 
-            // Only treat as a pin if there's a CVE/GHSA/security comment
             if (comment && (comment.toUpperCase().contains('CVE') ||
                             comment.toUpperCase().contains('GHSA') ||
                             comment.toLowerCase().contains('security'))) {
@@ -251,29 +240,21 @@ def detectSpringBootVersion(Project project) {
 
 // ── Maven Central Queries ──────────────────────────────────────────────────────
 
-/**
- * Fetches Spring Boot versions newer than the current one from Maven Central.
- * Stays within the same major.minor series (e.g., 3.5.x) by default,
- * but also checks the next minor (e.g., 3.6.x) if available.
- */
-def fetchNewerSpringBootVersions(String currentVersion, Project project) {
+def fetchNewerSpringBootVersions(String currentVersion) {
     def parts = currentVersion.tokenize('.')
     if (parts.size() < 3) return []
 
     def major = parts[0]
     def minor = parts[1]
-    def patch = parts[2] as int
 
     def versions = []
 
-    // Fetch same minor series
     versions.addAll(fetchVersionsFromMavenCentral(
         'org.springframework.boot',
         'spring-boot-starter-parent',
         "${major}.${minor}"
     ))
 
-    // Also check next minor
     def nextMinor = (minor as int) + 1
     versions.addAll(fetchVersionsFromMavenCentral(
         'org.springframework.boot',
@@ -291,7 +272,10 @@ def fetchVersionsFromMavenCentral(String group, String artifact, String versionP
     def metadataUrl = "https://repo1.maven.org/maven2/${groupPath}/${artifact}/maven-metadata.xml"
 
     try {
-        def metadata = new XmlSlurper().parseText(new URL(metadataUrl).text)
+        def conn = new URL(metadataUrl).openConnection()
+        conn.connectTimeout = 5000
+        conn.readTimeout = 10000
+        def metadata = new XmlSlurper().parseText(conn.inputStream.text)
         return metadata.versioning.versions.version
             .collect { it.text() }
             .findAll { it.startsWith(versionPrefix) }
@@ -303,38 +287,26 @@ def fetchVersionsFromMavenCentral(String group, String artifact, String versionP
 
 // ── Detached Resolution ────────────────────────────────────────────────────────
 
-/**
- * Creates a throwaway Gradle configuration with a specific Spring Boot BOM version,
- * adds the target dependency, and resolves it to see what version the BOM provides.
- */
 def resolveWithBom(Project project, String bootVersion, String group, String artifactName) {
+    def platformDep = project.dependencies.platform(
+        "org.springframework.boot:spring-boot-dependencies:${bootVersion}")
+
+    def resolveArtifact = artifactName.endsWith('*')
+        ? artifactName.replace('*', 'r4')
+        : artifactName
+
+    def targetDep = project.dependencies.create("${group}:${resolveArtifact}")
+
+    def detached = project.configurations.detachedConfiguration(platformDep, targetDep)
+    detached.transitive = true
+
     try {
-        def configName = "auditProbe_${bootVersion.replace('.', '_')}_${artifactName.replace('.', '_')}_${System.nanoTime()}"
-
-        def detached = project.configurations.create(configName) {
-            canBeConsumed = false
-            canBeResolved = true
-            transitive = true
-        }
-
-        project.dependencies.add(configName,
-            project.dependencies.platform("org.springframework.boot:spring-boot-dependencies:${bootVersion}"))
-
-        // For wildcard pins (e.g., org.hl7.fhir.*), pick a representative artifact
-        def resolveArtifact = artifactName.endsWith('*')
-            ? artifactName.replace('*', 'r4')
-            : artifactName
-
-        project.dependencies.add(configName, "${group}:${resolveArtifact}")
-
         def resolved = detached.resolvedConfiguration.resolvedArtifacts.find {
             it.moduleVersion.id.group == group &&
             (artifactName.endsWith('*')
                 ? it.moduleVersion.id.name.startsWith(artifactName.replace('*', ''))
                 : it.moduleVersion.id.name == resolveArtifact)
         }
-
-        project.configurations.remove(detached)
         return resolved?.moduleVersion?.id?.version
     } catch (Exception e) {
         return null
@@ -347,23 +319,18 @@ def resolveWithBom(Project project, String bootVersion, String group, String art
  * For pins that target transitive dependencies (e.g., org.hl7.fhir.* forced to 6.9.0),
  * checks whether upgrading the direct parent dependency (e.g., hapi-fhir-structures-r4)
  * would bring in the pinned version transitively, eliminating the need for the force.
- *
- * Detects the parent by scanning build.gradle for direct dependency declarations
- * that share the same group as the pin, then checks newer versions of that parent.
  */
 def checkParentDependencyUpgrades(Project project, List pins) {
     def results = []
     def buildContent = project.file('build.gradle').text
 
     pins.each { pin ->
-        // Find direct dependencies in build.gradle with the same group
         def directDeps = findDirectDependencies(buildContent, pin.group)
         if (directDeps.isEmpty()) return
 
         def parentArtifact = directDeps.first()
         def currentParentVersion = parentArtifact.version
 
-        // Fetch newer versions of the parent artifact
         def newerParentVersions = fetchNewerVersionsOf(
             parentArtifact.group, parentArtifact.name, currentParentVersion
         )
@@ -394,29 +361,30 @@ def checkParentDependencyUpgrades(Project project, List pins) {
 def findDirectDependencies(String buildContent, String group) {
     def deps = []
     def seen = [] as Set
+    def quotedGroup = java.util.regex.Pattern.quote(group)
 
     // Pattern: implementation "group:artifact:${varName}"
-    def varPattern = ~/(?:implementation|api|compileOnly)\s+["']${java.util.regex.Pattern.quote(group)}:([^:'"]+):\$\{(\w+)\}["']/
-    buildContent.findAll(varPattern) { match ->
-        def artifactName = match[1]
-        def varName = match[2]
-        def varValue = (buildContent =~ /set\(\s*['"]${varName}['"]\s*,\s*['"]([^'"]+)['"]\s*\)/)
-        if (varValue) {
+    Matcher varMatcher = buildContent =~ /(?:implementation|api|compileOnly)\s+["']${quotedGroup}:([^:'"]+):\$\{(\w+)\}["']/
+    while (varMatcher.find()) {
+        def artifactName = varMatcher.group(1)
+        def varName = varMatcher.group(2)
+        Matcher varValue = buildContent =~ /set\(\s*['"]${varName}['"]\s*,\s*['"]([^'"]+)['"]\s*\)/
+        if (varValue.find()) {
             def key = "${group}:${artifactName}"
             if (!seen.contains(key)) {
                 seen << key
-                deps << [group: group, name: artifactName, version: varValue[0][1]]
+                deps << [group: group, name: artifactName, version: varValue.group(1)]
             }
         }
     }
 
     // Pattern: implementation "group:artifact:1.2.3" (literal version, no variable)
-    def literalPattern = ~/(?:implementation|api|compileOnly)\s+['"]${java.util.regex.Pattern.quote(group)}:([^:'"]+):([^'"\$]+)['"]/
-    buildContent.findAll(literalPattern) { match ->
-        def key = "${group}:${match[1]}"
+    Matcher litMatcher = buildContent =~ /(?:implementation|api|compileOnly)\s+['"]${quotedGroup}:([^:'"]+):([^'"\$]+)['"]/
+    while (litMatcher.find()) {
+        def key = "${group}:${litMatcher.group(1)}"
         if (!seen.contains(key)) {
             seen << key
-            deps << [group: group, name: match[1], version: match[2]]
+            deps << [group: group, name: litMatcher.group(1), version: litMatcher.group(2)]
         }
     }
 
@@ -431,9 +399,7 @@ def fetchNewerVersionsOf(String group, String artifact, String currentVersion) {
     def minor = parts[1]
 
     def versions = []
-    // Same minor
     versions.addAll(fetchVersionsFromMavenCentral(group, artifact, "${major}.${minor}"))
-    // Next minor
     def nextMinor = (minor as int) + 1
     versions.addAll(fetchVersionsFromMavenCentral(group, artifact, "${major}.${nextMinor}"))
 
@@ -442,23 +408,13 @@ def fetchNewerVersionsOf(String group, String artifact, String currentVersion) {
         .sort { a, b -> compareVersions(a, b) }
 }
 
-/**
- * Resolves a parent dependency at a candidate version and checks what version
- * of the target transitive dependency it brings in.
- */
 def resolveTransitiveDep(Project project, String parentGroup, String parentArtifact,
                           String parentVersion, String targetGroup, String targetName) {
+    def parentDep = project.dependencies.create("${parentGroup}:${parentArtifact}:${parentVersion}")
+    def detached = project.configurations.detachedConfiguration(parentDep)
+    detached.transitive = true
+
     try {
-        def configName = "auditTransitive_${parentVersion.replace('.', '_')}_${System.nanoTime()}"
-
-        def detached = project.configurations.create(configName) {
-            canBeConsumed = false
-            canBeResolved = true
-            transitive = true
-        }
-
-        project.dependencies.add(configName, "${parentGroup}:${parentArtifact}:${parentVersion}")
-
         def resolveTarget = targetName.endsWith('*')
             ? targetName.replace('*', 'r4')
             : targetName
@@ -469,8 +425,6 @@ def resolveTransitiveDep(Project project, String parentGroup, String parentArtif
                 ? it.moduleVersion.id.name.startsWith(targetName.replace('*', ''))
                 : it.moduleVersion.id.name == resolveTarget)
         }
-
-        project.configurations.remove(detached)
         return resolved?.moduleVersion?.id?.version
     } catch (Exception e) {
         return null

--- a/gradle/audit-version-pins.gradle
+++ b/gradle/audit-version-pins.gradle
@@ -128,6 +128,10 @@ tasks.register('auditVersionPins') {
     }
 }
 
+tasks.named('check') {
+    dependsOn 'auditVersionPins'
+}
+
 // ── Pin Detection ──────────────────────────────────────────────────────────────
 
 /**

--- a/gradle/audit-version-pins.gradle
+++ b/gradle/audit-version-pins.gradle
@@ -1,0 +1,507 @@
+/**
+ * Audit Version Pins — discovers forced dependency overrides in build.gradle and checks
+ * whether a newer Spring Boot BOM (or other parent BOM) would resolve those deps
+ * to the pinned version or higher, making the pin removable.
+ *
+ * Usage (option A — download via Gradle task, preferred):
+ *   Add to downloadAllDocs or a separate downloadGradleScripts task that pulls this file
+ *   from hp-code-conventions into gradle/audit-version-pins.gradle, then:
+ *     apply from: 'gradle/audit-version-pins.gradle'
+ *
+ * Usage (option B — apply directly from GitHub):
+ *   apply from: 'https://raw.githubusercontent.com/icanbwell/hp-code-conventions/main/gradle/audit-version-pins.gradle'
+ *
+ * Then run:
+ *   ./gradlew auditVersionPins
+ *
+ * The task reads the project's current Spring Boot plugin version, queries Maven Central
+ * for newer patch/minor releases, resolves the pinned dependencies against each candidate
+ * BOM, and reports which upgrades would eliminate which pins.
+ */
+
+import groovy.xml.XmlSlurper
+
+tasks.register('auditVersionPins') {
+    group = 'verification'
+    description = 'Checks if newer BOM versions would resolve forced dependency pins'
+
+    doLast {
+        def pins = detectVersionPins(project)
+        if (pins.isEmpty()) {
+            logger.lifecycle("\n✓ No forced version pins detected in build.gradle.")
+            return
+        }
+
+        logger.lifecycle("\n── Detected version pins ─────────────────────────")
+        pins.each { pin ->
+            logger.lifecycle("  ${pin.group}:${pin.name} → ${pin.forcedVersion}  (${pin.reason})")
+        }
+
+        def currentBootVersion = detectSpringBootVersion(project)
+        if (!currentBootVersion) {
+            logger.lifecycle("\n⚠ Could not detect Spring Boot plugin version. Skipping BOM upgrade check.")
+            return
+        }
+        logger.lifecycle("\n── Current Spring Boot version: ${currentBootVersion}")
+
+        def newerVersions = fetchNewerSpringBootVersions(currentBootVersion, project)
+        if (newerVersions.isEmpty()) {
+            logger.lifecycle("  No newer Spring Boot versions found on Maven Central.")
+            return
+        }
+        logger.lifecycle("  Candidate upgrades: ${newerVersions.join(', ')}")
+
+        logger.lifecycle("\n── Pin resolution analysis ───────────────────────")
+
+        def removablePins = [:]
+
+        newerVersions.each { candidateVersion ->
+            pins.each { pin ->
+                if (removablePins.containsKey(pinKey(pin))) return
+
+                def resolvedVersion = resolveWithBom(project, candidateVersion, pin.group, pin.name)
+                if (resolvedVersion && isVersionSufficient(resolvedVersion, pin.forcedVersion)) {
+                    removablePins[pinKey(pin)] = [
+                        pin: pin,
+                        resolvedBy: candidateVersion,
+                        bomResolvesTo: resolvedVersion
+                    ]
+                }
+            }
+        }
+
+        logger.lifecycle("")
+        if (removablePins.isEmpty()) {
+            logger.lifecycle("  No pins can be removed by upgrading Spring Boot to any available version.")
+            logger.lifecycle("  Tested up to: ${newerVersions.last()}")
+        } else {
+            logger.lifecycle("  ┌─────────────────────────────────────────────────────────────────┐")
+            logger.lifecycle("  │ REMOVABLE PINS                                                  │")
+            logger.lifecycle("  ├─────────────────────────────────────────────────────────────────┤")
+            removablePins.values().each { result ->
+                def pin = result.pin
+                logger.lifecycle("  │ ${pin.group}:${pin.name}")
+                logger.lifecycle("  │   Pinned to:  ${pin.forcedVersion}")
+                logger.lifecycle("  │   BOM gives:  ${result.bomResolvesTo}  (Spring Boot ${result.resolvedBy})")
+                logger.lifecycle("  │   Action:     Upgrade Spring Boot ${currentBootVersion} → ${result.resolvedBy}, remove pin")
+                logger.lifecycle("  │")
+            }
+            logger.lifecycle("  └─────────────────────────────────────────────────────────────────┘")
+        }
+
+        def stillPinned = pins.findAll { !removablePins.containsKey(pinKey(it)) }
+
+        // For pins not resolvable via Spring Boot BOM, check if upgrading the direct
+        // parent dependency would transitively include the pinned version.
+        // E.g., upgrading HAPI FHIR might bring in a fixed org.hl7.fhir.core version.
+        if (!stillPinned.isEmpty()) {
+            def parentUpgrades = checkParentDependencyUpgrades(project, stillPinned)
+            if (!parentUpgrades.isEmpty()) {
+                logger.lifecycle("")
+                logger.lifecycle("  ┌─────────────────────────────────────────────────────────────────┐")
+                logger.lifecycle("  │ REMOVABLE VIA PARENT DEPENDENCY UPGRADE                         │")
+                logger.lifecycle("  ├─────────────────────────────────────────────────────────────────┤")
+                parentUpgrades.each { result ->
+                    def pin = result.pin
+                    logger.lifecycle("  │ ${pin.group}:${pin.name}")
+                    logger.lifecycle("  │   Pinned to:     ${pin.forcedVersion}")
+                    logger.lifecycle("  │   Parent lib:    ${result.parentGroup}:${result.parentArtifact}")
+                    logger.lifecycle("  │   Current ver:   ${result.currentParentVersion}")
+                    logger.lifecycle("  │   Upgrade to:    ${result.upgradeParentVersion}  (resolves transitive to ${result.transitiveVersion})")
+                    logger.lifecycle("  │   Action:        Upgrade ${result.parentArtifact} ${result.currentParentVersion} → ${result.upgradeParentVersion}, remove pin")
+                    logger.lifecycle("  │")
+                    removablePins[pinKey(pin)] = result
+                }
+                logger.lifecycle("  └─────────────────────────────────────────────────────────────────┘")
+            }
+        }
+
+        stillPinned = pins.findAll { !removablePins.containsKey(pinKey(it)) }
+        if (!stillPinned.isEmpty()) {
+            logger.lifecycle("")
+            logger.lifecycle("  Still required (no available upgrade resolves these):")
+            stillPinned.each { pin ->
+                logger.lifecycle("    ${pin.group}:${pin.name} → ${pin.forcedVersion}")
+            }
+        }
+        logger.lifecycle("")
+    }
+}
+
+// ── Pin Detection ──────────────────────────────────────────────────────────────
+
+/**
+ * Scans the project's configurations for eachDependency forced versions
+ * and ext property overrides that follow Spring Boot's naming convention.
+ *
+ * Returns a list of maps: [group, name, forcedVersion, reason, type]
+ */
+def detectVersionPins(Project project) {
+    def pins = []
+    def buildFile = project.file('build.gradle')
+    if (!buildFile.exists()) return pins
+
+    def lines = buildFile.readLines()
+
+    // Pattern 1: resolutionStrategy.eachDependency forced version blocks
+    // Parses the if-block line by line to find group, name, useVersion, because
+    String currentGroup = null
+    String currentName = null
+    boolean inIfBlock = false
+
+    lines.each { line ->
+        def stripped = line.trim()
+
+        def ifMatch = (stripped =~ /if\s*\(\s*details\.requested\.group\s*==\s*['"]([^'"]+)['"]/)
+        if (ifMatch) {
+            currentGroup = ifMatch[0][1]
+            inIfBlock = true
+
+            def nameStartsWith = (stripped =~ /name\.startsWith\(\s*['"]([^'"]+)['"]\s*\)/)
+            def nameEquals = (stripped =~ /name\s*==\s*['"]([^'"]+)['"]/)
+            if (nameStartsWith) {
+                currentName = "${nameStartsWith[0][1]}*"
+            } else if (nameEquals) {
+                currentName = nameEquals[0][1]
+            }
+        }
+
+        if (inIfBlock) {
+            def versionMatch = (stripped =~ /details\.useVersion\s+['"]([^'"]+)['"]/)
+            if (versionMatch) {
+                def version = versionMatch[0][1]
+                def becauseMatch = null
+                // Look for because on same line or scan ahead
+                def becauseLine = (stripped =~ /details\.because\s+['"]([^'"]+)['"]/)
+                def reason = becauseLine ? becauseLine[0][1] : null
+
+                if (!reason) {
+                    // Check next few lines for the because clause
+                    def lineIdx = lines.indexOf(line)
+                    for (int i = lineIdx + 1; i < Math.min(lineIdx + 3, lines.size()); i++) {
+                        def nextBecause = (lines[i].trim() =~ /details\.because\s+['"]([^'"]+)['"]/)
+                        if (nextBecause) {
+                            reason = nextBecause[0][1]
+                            break
+                        }
+                    }
+                }
+
+                pins << [
+                    group: currentGroup,
+                    name: currentName ?: '*',
+                    forcedVersion: version,
+                    reason: reason ?: 'no reason given',
+                    type: 'eachDependency'
+                ]
+            }
+
+            if (stripped.contains('}')) {
+                inIfBlock = false
+                currentGroup = null
+                currentName = null
+            }
+        }
+    }
+
+    // Pattern 2: ext.set version overrides that are security pins
+    // Spring Boot's dependency-management plugin uses property names like 'thymeleaf.version'
+    // to override BOM-managed versions. We only flag these as pins if they have a CVE/GHSA
+    // comment, distinguishing security overrides from normal version declarations.
+    lines.each { line ->
+        def stripped = line.trim()
+        def extMatch = (stripped =~ /set\(\s*['"]([^'"]+)\.version['"]\s*,\s*['"]([^'"]+)['"]\s*\)/)
+        if (extMatch) {
+            def artifactHint = extMatch[0][1]
+            def version = extMatch[0][2]
+            def commentMatch = (stripped =~ /\/\/\s*(.+)$/)
+            def comment = commentMatch ? commentMatch[0][1].trim() : null
+
+            // Only treat as a pin if there's a CVE/GHSA/security comment
+            if (comment && (comment.toUpperCase().contains('CVE') ||
+                            comment.toUpperCase().contains('GHSA') ||
+                            comment.toLowerCase().contains('security'))) {
+                pins << [
+                    group: artifactHint,
+                    name: artifactHint,
+                    forcedVersion: version,
+                    reason: comment,
+                    type: 'extProperty'
+                ]
+            }
+        }
+    }
+
+    return pins
+}
+
+// ── Spring Boot Version Detection ──────────────────────────────────────────────
+
+def detectSpringBootVersion(Project project) {
+    def buildFile = project.file('build.gradle')
+    if (!buildFile.exists()) return null
+
+    def match = (buildFile.text =~ /id\s+['"]org\.springframework\.boot['"]\s+version\s+['"]([^'"]+)['"]/)
+    return match ? match[0][1] : null
+}
+
+// ── Maven Central Queries ──────────────────────────────────────────────────────
+
+/**
+ * Fetches Spring Boot versions newer than the current one from Maven Central.
+ * Stays within the same major.minor series (e.g., 3.5.x) by default,
+ * but also checks the next minor (e.g., 3.6.x) if available.
+ */
+def fetchNewerSpringBootVersions(String currentVersion, Project project) {
+    def parts = currentVersion.tokenize('.')
+    if (parts.size() < 3) return []
+
+    def major = parts[0]
+    def minor = parts[1]
+    def patch = parts[2] as int
+
+    def versions = []
+
+    // Fetch same minor series
+    versions.addAll(fetchVersionsFromMavenCentral(
+        'org.springframework.boot',
+        'spring-boot-starter-parent',
+        "${major}.${minor}"
+    ))
+
+    // Also check next minor
+    def nextMinor = (minor as int) + 1
+    versions.addAll(fetchVersionsFromMavenCentral(
+        'org.springframework.boot',
+        'spring-boot-starter-parent',
+        "${major}.${nextMinor}"
+    ))
+
+    return versions
+        .findAll { isVersionNewer(it, currentVersion) }
+        .sort { a, b -> compareVersions(a, b) }
+}
+
+def fetchVersionsFromMavenCentral(String group, String artifact, String versionPrefix) {
+    def groupPath = group.replace('.', '/')
+    def metadataUrl = "https://repo1.maven.org/maven2/${groupPath}/${artifact}/maven-metadata.xml"
+
+    try {
+        def metadata = new XmlSlurper().parseText(new URL(metadataUrl).text)
+        return metadata.versioning.versions.version
+            .collect { it.text() }
+            .findAll { it.startsWith(versionPrefix) }
+            .findAll { !it.contains('-SNAPSHOT') && !it.contains('-RC') && !it.contains('-M') }
+    } catch (Exception e) {
+        return []
+    }
+}
+
+// ── Detached Resolution ────────────────────────────────────────────────────────
+
+/**
+ * Creates a throwaway Gradle configuration with a specific Spring Boot BOM version,
+ * adds the target dependency, and resolves it to see what version the BOM provides.
+ */
+def resolveWithBom(Project project, String bootVersion, String group, String artifactName) {
+    try {
+        def configName = "auditProbe_${bootVersion.replace('.', '_')}_${artifactName.replace('.', '_')}_${System.nanoTime()}"
+
+        def detached = project.configurations.create(configName) {
+            canBeConsumed = false
+            canBeResolved = true
+            transitive = true
+        }
+
+        project.dependencies.add(configName,
+            project.dependencies.platform("org.springframework.boot:spring-boot-dependencies:${bootVersion}"))
+
+        // For wildcard pins (e.g., org.hl7.fhir.*), pick a representative artifact
+        def resolveArtifact = artifactName.endsWith('*')
+            ? artifactName.replace('*', 'r4')
+            : artifactName
+
+        project.dependencies.add(configName, "${group}:${resolveArtifact}")
+
+        def resolved = detached.resolvedConfiguration.resolvedArtifacts.find {
+            it.moduleVersion.id.group == group &&
+            (artifactName.endsWith('*')
+                ? it.moduleVersion.id.name.startsWith(artifactName.replace('*', ''))
+                : it.moduleVersion.id.name == resolveArtifact)
+        }
+
+        project.configurations.remove(detached)
+        return resolved?.moduleVersion?.id?.version
+    } catch (Exception e) {
+        return null
+    }
+}
+
+// ── Parent Dependency Upgrade Check ────────────────────────────────────────────
+
+/**
+ * For pins that target transitive dependencies (e.g., org.hl7.fhir.* forced to 6.9.0),
+ * checks whether upgrading the direct parent dependency (e.g., hapi-fhir-structures-r4)
+ * would bring in the pinned version transitively, eliminating the need for the force.
+ *
+ * Detects the parent by scanning build.gradle for direct dependency declarations
+ * that share the same group as the pin, then checks newer versions of that parent.
+ */
+def checkParentDependencyUpgrades(Project project, List pins) {
+    def results = []
+    def buildContent = project.file('build.gradle').text
+
+    pins.each { pin ->
+        // Find direct dependencies in build.gradle with the same group
+        def directDeps = findDirectDependencies(buildContent, pin.group)
+        if (directDeps.isEmpty()) return
+
+        def parentArtifact = directDeps.first()
+        def currentParentVersion = parentArtifact.version
+
+        // Fetch newer versions of the parent artifact
+        def newerParentVersions = fetchNewerVersionsOf(
+            parentArtifact.group, parentArtifact.name, currentParentVersion
+        )
+
+        for (candidateVersion in newerParentVersions) {
+            def transitiveVersion = resolveTransitiveDep(
+                project, parentArtifact.group, parentArtifact.name,
+                candidateVersion, pin.group, pin.name
+            )
+
+            if (transitiveVersion && isVersionSufficient(transitiveVersion, pin.forcedVersion)) {
+                results << [
+                    pin: pin,
+                    parentGroup: parentArtifact.group,
+                    parentArtifact: parentArtifact.name,
+                    currentParentVersion: currentParentVersion,
+                    upgradeParentVersion: candidateVersion,
+                    transitiveVersion: transitiveVersion
+                ]
+                break
+            }
+        }
+    }
+
+    return results
+}
+
+def findDirectDependencies(String buildContent, String group) {
+    def deps = []
+    def seen = [] as Set
+
+    // Pattern: implementation "group:artifact:${varName}"
+    def varPattern = ~/(?:implementation|api|compileOnly)\s+["']${java.util.regex.Pattern.quote(group)}:([^:'"]+):\$\{(\w+)\}["']/
+    buildContent.findAll(varPattern) { match ->
+        def artifactName = match[1]
+        def varName = match[2]
+        def varValue = (buildContent =~ /set\(\s*['"]${varName}['"]\s*,\s*['"]([^'"]+)['"]\s*\)/)
+        if (varValue) {
+            def key = "${group}:${artifactName}"
+            if (!seen.contains(key)) {
+                seen << key
+                deps << [group: group, name: artifactName, version: varValue[0][1]]
+            }
+        }
+    }
+
+    // Pattern: implementation "group:artifact:1.2.3" (literal version, no variable)
+    def literalPattern = ~/(?:implementation|api|compileOnly)\s+['"]${java.util.regex.Pattern.quote(group)}:([^:'"]+):([^'"\$]+)['"]/
+    buildContent.findAll(literalPattern) { match ->
+        def key = "${group}:${match[1]}"
+        if (!seen.contains(key)) {
+            seen << key
+            deps << [group: group, name: match[1], version: match[2]]
+        }
+    }
+
+    return deps
+}
+
+def fetchNewerVersionsOf(String group, String artifact, String currentVersion) {
+    def parts = currentVersion.tokenize('.')
+    if (parts.size() < 2) return []
+
+    def major = parts[0]
+    def minor = parts[1]
+
+    def versions = []
+    // Same minor
+    versions.addAll(fetchVersionsFromMavenCentral(group, artifact, "${major}.${minor}"))
+    // Next minor
+    def nextMinor = (minor as int) + 1
+    versions.addAll(fetchVersionsFromMavenCentral(group, artifact, "${major}.${nextMinor}"))
+
+    return versions
+        .findAll { isVersionNewer(it, currentVersion) }
+        .sort { a, b -> compareVersions(a, b) }
+}
+
+/**
+ * Resolves a parent dependency at a candidate version and checks what version
+ * of the target transitive dependency it brings in.
+ */
+def resolveTransitiveDep(Project project, String parentGroup, String parentArtifact,
+                          String parentVersion, String targetGroup, String targetName) {
+    try {
+        def configName = "auditTransitive_${parentVersion.replace('.', '_')}_${System.nanoTime()}"
+
+        def detached = project.configurations.create(configName) {
+            canBeConsumed = false
+            canBeResolved = true
+            transitive = true
+        }
+
+        project.dependencies.add(configName, "${parentGroup}:${parentArtifact}:${parentVersion}")
+
+        def resolveTarget = targetName.endsWith('*')
+            ? targetName.replace('*', 'r4')
+            : targetName
+
+        def resolved = detached.resolvedConfiguration.resolvedArtifacts.find {
+            it.moduleVersion.id.group == targetGroup &&
+            (targetName.endsWith('*')
+                ? it.moduleVersion.id.name.startsWith(targetName.replace('*', ''))
+                : it.moduleVersion.id.name == resolveTarget)
+        }
+
+        project.configurations.remove(detached)
+        return resolved?.moduleVersion?.id?.version
+    } catch (Exception e) {
+        return null
+    }
+}
+
+// ── Version Comparison ─────────────────────────────────────────────────────────
+
+def isVersionSufficient(String resolved, String required) {
+    return compareVersions(resolved, required) >= 0
+}
+
+def isVersionNewer(String candidate, String current) {
+    return compareVersions(candidate, current) > 0
+}
+
+def compareVersions(String a, String b) {
+    def normalize = { String v ->
+        v.replace('.RELEASE', '')
+         .replace('.Final', '')
+         .tokenize('.')
+         .collect { it.isInteger() ? it as int : 0 }
+    }
+    def aParts = normalize(a)
+    def bParts = normalize(b)
+    def maxLen = Math.max(aParts.size(), bParts.size())
+
+    for (int i = 0; i < maxLen; i++) {
+        def aVal = i < aParts.size() ? aParts[i] : 0
+        def bVal = i < bParts.size() ? bParts[i] : 0
+        if (aVal != bVal) return aVal <=> bVal
+    }
+    return 0
+}
+
+def pinKey(Map pin) {
+    return "${pin.group}:${pin.name}"
+}


### PR DESCRIPTION
## Summary
- Adds `gradle/audit-version-pins.gradle` — a shared Gradle task that detects forced dependency version pins in `build.gradle` and checks whether upgrading the Spring Boot BOM or parent dependency would make them removable
- Updates `docs/agent-config/CLAUDE.md` with `auditVersionPins` build command and a "Dependency Version Pin Hygiene" section instructing agents to run the audit when touching dependencies

## How it works
1. Scans `build.gradle` for `resolutionStrategy.eachDependency` force blocks and `ext.set` security overrides (CVE/GHSA-annotated)
2. Queries Maven Central for newer Spring Boot BOM versions (same minor + next minor)
3. Creates detached Gradle configurations to resolve pinned deps against candidate BOMs
4. For non-BOM-managed deps (e.g., HAPI FHIR `org.hl7.fhir.*`), checks if upgrading the direct parent dependency would transitively resolve the pin
5. Reports actionable upgrade paths or confirms pins are still required

## Adoption
Each Java repo adds one line to `build.gradle`:
```groovy
apply from: 'https://raw.githubusercontent.com/icanbwell/hp-code-conventions/main/gradle/audit-version-pins.gradle'
```
Then `./gradlew auditVersionPins` is available.

## Test plan
- [x] Tested against hp-facade (FHIR pin correctly identified as still required — no newer HAPI version exists)
- [x] Tested against care-gap-evaluation-service (same result)
- [x] Verified `because` clause parsing works for multi-line if-blocks
- [x] Verified `ext.set` pattern only flags CVE/GHSA-annotated overrides, not normal version properties