### PR TITLE
INE-0001 Add PR Summary section to agent review output

### DIFF
--- a/docs/agent-context/OUTPUT_FORMAT.md
+++ b/docs/agent-context/OUTPUT_FORMAT.md
@@ -1,7 +1,17 @@
 # Output Format
 
-For every review, provide:
-- **Summary**: A high-level status (e.g., "Stable," "Contains Technical Debt," or "Critical Issues Found").
+For every review, provide the following sections in order:
+
+## PR Summary (always include)
+
+- **What this PR does**: 1-2 sentence plain-English summary of the change and its motivation.
+- **Key data flow**: How data moves through the system as a result of this change (entry point → processing → output/persistence). For config-only changes, describe what the config controls at runtime.
+- **Critical business logic**: Call out the most important or highest-impact code changes in this PR — the lines/files where core business rules, FHIR resource transformations, or key decision-making logic live. Be specific (file + method/line range). This helps human reviewers focus their time on what matters most.
+- **Human attention needed**: Things the bot cannot fully verify — environment config, deploy ordering, feature flag state, manual test scenarios, downstream consumer impact, or anything that requires domain knowledge to validate.
+
+## Review Findings
+
+- **Status**: A high-level status (e.g., "Stable," "Contains Technical Debt," or "Critical Issues Found").
 - **Categorized Feedback**:
     - [Critical/Reliability]: Fixes required for production safety.
     - [FHIR/Logic]: Alignment with business and FHIR standards.


### PR DESCRIPTION
## Summary
- Adds a structured "PR Summary" section to the CI review agent's output format
- Summary includes: what the PR does, key data flow, critical business logic locations (specific files/methods), and items needing human attention
- Once repos run `downloadAllDocs`, the review agent will automatically include this summary at the top of every PR review comment

## Test plan
- [ ] Merge and verify next PR in task-service (or any repo with `downloadAllDocs`) produces a review comment with the new summary section
- [ ] Confirm the summary correctly identifies critical business logic and doesn't just restate the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)